### PR TITLE
[FEAT] 통합 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'io.jsonwebtoken:jjwt:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.internal.publish.checksums.insecure=true

--- a/src/main/java/com/example/believeus/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/believeus/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.example.believeus.auth;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = extractToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Claims claims = jwtTokenProvider.getClaimsFromToken(token);
+            UserDetails userDetails = new User(claims.getSubject(), "", Collections.emptyList());
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/believeus/auth/JwtTokenProvider.java
+++ b/src/main/java/com/example/believeus/auth/JwtTokenProvider.java
@@ -1,11 +1,11 @@
 package com.example.believeus.auth;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;
 import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,13 +13,12 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
-import java.security.Key;
 import java.util.Date;
 
 @Slf4j
 @Component
 public class JwtTokenProvider {
-    private final Key key;
+    private final SecretKey key;
     private final long accessTokenExpiration;
     private final long refreshTokenExpiration;
 
@@ -56,7 +55,7 @@ public class JwtTokenProvider {
     public boolean validateToken(String token) {
         try {
             Jwts.parser()
-                    .verifyWith((SecretKey) key)
+                    .verifyWith(key)
                     .build()
                     .parseSignedClaims(token);
             return true;
@@ -77,10 +76,19 @@ public class JwtTokenProvider {
     // 토큰에서 사용자 정보 추출
     public String getUsernameFromToken(String token) {
         Claims claims = Jwts.parser()
-                .verifyWith((SecretKey) key)
+                .verifyWith(key)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
         return claims.getSubject();
+    }
+
+    // 토큰에서 Claims 정보 추출
+    public Claims getClaimsFromToken(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 }

--- a/src/main/java/com/example/believeus/auth/JwtTokenProvider.java
+++ b/src/main/java/com/example/believeus/auth/JwtTokenProvider.java
@@ -1,0 +1,86 @@
+package com.example.believeus.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+    private final Key key;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-expiration}") long accessTokenExpiration,
+            @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
+    }
+
+    // JWT 토큰 생성
+    public String generateToken(String username, long expiration) {
+        return Jwts.builder()
+                .subject(username)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(key)
+                .compact();
+    }
+
+    // 액세스 토큰 생성
+    public String generateAccessToken(String username) {
+        return generateToken(username, accessTokenExpiration);
+    }
+
+    // 리프레시 토큰 생성
+    public String generateRefreshToken(String username) {
+        return generateToken(username, refreshTokenExpiration);
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith((SecretKey) key)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.error("JWT 토큰이 만료되었습니다: {}", e.getMessage());
+        } catch (MalformedJwtException e) {
+            log.error("JWT 토큰이 올바르지 않습니다: {}", e.getMessage());
+        } catch (SignatureException e) {
+            log.error("JWT 서명 검증 실패: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰입니다: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 토큰이 잘못되었습니다: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    // 토큰에서 사용자 정보 추출
+    public String getUsernameFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith((SecretKey) key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return claims.getSubject();
+    }
+}

--- a/src/main/java/com/example/believeus/auth/application/AuthService.java
+++ b/src/main/java/com/example/believeus/auth/application/AuthService.java
@@ -1,0 +1,36 @@
+package com.example.believeus.auth.application;
+
+import com.example.believeus.auth.JwtTokenProvider;
+import com.example.believeus.auth.dto.LoginRequest;
+import com.example.believeus.auth.dto.LoginResponse;
+import com.example.believeus.caregiver.domain.Caregiver;
+import com.example.believeus.caregiver.repository.CaregiverRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final CaregiverRepository caregiverRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public LoginResponse login(LoginRequest request) {
+        // 유저 조회
+        Caregiver caregiver = caregiverRepository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 잘못되었습니다."));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(request.getPassword(), caregiver.getPassword())) {
+            throw new IllegalArgumentException("아이디 또는 비밀번호가 잘못되었습니다.");
+        }
+
+        // JWT 토큰 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(caregiver.getUsername());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(caregiver.getUsername());
+
+        return new LoginResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/example/believeus/auth/application/CustomUserDetailsService.java
+++ b/src/main/java/com/example/believeus/auth/application/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.example.believeus.auth.application;
+
+import com.example.believeus.caregiver.domain.Caregiver;
+import com.example.believeus.caregiver.repository.CaregiverRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final CaregiverRepository caregiverRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        // 아이디(username)로 사용자 찾기
+        Caregiver caregiver = caregiverRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+
+        // UserDetails 객체 반환
+        return User.builder()
+                .username(caregiver.getUsername())
+                .password(caregiver.getPassword())
+                .roles("USER")  // 기본 권한 부여
+                .build();
+    }
+}

--- a/src/main/java/com/example/believeus/auth/controller/AuthController.java
+++ b/src/main/java/com/example/believeus/auth/controller/AuthController.java
@@ -1,0 +1,21 @@
+package com.example.believeus.auth.controller;
+
+import com.example.believeus.auth.dto.LoginRequest;
+import com.example.believeus.auth.dto.LoginResponse;
+import com.example.believeus.auth.application.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/believeus/auth/controller/AuthController.java
+++ b/src/main/java/com/example/believeus/auth/controller/AuthController.java
@@ -3,15 +3,26 @@ package com.example.believeus.auth.controller;
 import com.example.believeus.auth.dto.LoginRequest;
 import com.example.believeus.auth.dto.LoginResponse;
 import com.example.believeus.auth.application.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Common Auth API", description = "공통 인증/인가 API")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+
+    @Operation(summary = "통합 로그인", description = "요양보호사/관리자 통합 로그인 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "403", description = "인증 실패"),
+    })
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {

--- a/src/main/java/com/example/believeus/auth/dto/LoginRequest.java
+++ b/src/main/java/com/example/believeus/auth/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.example.believeus.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/example/believeus/auth/dto/LoginResponse.java
+++ b/src/main/java/com/example/believeus/auth/dto/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.example.believeus.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/believeus/caregiver/domain/CertificateType.java
+++ b/src/main/java/com/example/believeus/caregiver/domain/CertificateType.java
@@ -1,36 +1,9 @@
 package com.example.believeus.caregiver.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
-import lombok.Getter;
-
-@Getter
 public enum CertificateType {
-    CAREGIVER("요양보호사"),
-    SOCIAL_WORKER_L1("사회복지사 1급"),
-    SOCIAL_WORKER_L2("사회복지사 2급"),
-    NURSING_ASSISTANT_L1("간호조무사 1급"),
-    NURSING_ASSISTANT_L2("간호조무사 2급");
-
-    private final String displayName;
-
-    CertificateType(String displayName) {
-        this.displayName = displayName;
-    }
-
-    @JsonValue
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    @JsonCreator
-    public static CertificateType fromValue(@JsonProperty("certificateType") String value) {
-        for (CertificateType type : CertificateType.values()) {
-            if (type.getDisplayName().equals(value)) {
-                return type;
-            }
-        }
-        throw new IllegalArgumentException("Invalid certificate type: " + value);
-    }
+    CAREGIVER,
+    SOCIAL_WORKER_L1,
+    SOCIAL_WORKER_L2,
+    NURSING_ASSISTANT_L1,
+    NURSING_ASSISTANT_L2;
 }

--- a/src/main/java/com/example/believeus/caregiver/dto/CaregiverSignupRequest.java
+++ b/src/main/java/com/example/believeus/caregiver/dto/CaregiverSignupRequest.java
@@ -3,8 +3,8 @@ package com.example.believeus.caregiver.dto;
 import com.example.believeus.caregiver.domain.CertificateType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,30 +27,25 @@ public class CaregiverSignupRequest {
     private String name;
 
     @NotBlank(message = "전화번호는 필수 입력 항목입니다.")
-    @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
     private String phoneNumber;
 
-    @NotBlank(message = "요양보호사 자격증 번호는 필수 입력 항목입니다.")
-    @Pattern(regexp = "^제 \\d{4}-\\d{7}호$", message = "올바른 자격증 번호 형식이 아닙니다.")
-    private String caregiverCertificateNumber;
-
-    @NotNull(message = "자격증 종류는 필수 선택입니다.")
-    private List<CertificateType> additionalCertificates; // 사회복지사/간호조무사 등 추가 자격증
-
-    private boolean hasVehicle;             // 차량 소유 여부
-    private boolean hasDementiaTraining;    // 치매교육 이수 여부
+    private boolean hasVehicle;
+    private boolean hasDementiaTraining;
 
     // 선택 입력 항목
-    private String experienceYears;         // 경력 기간
-    private String majorExperience;         // 주요 경력
-    private String introduction;            // 한 줄 소개
-    private String profileImageUrl;         // 프로필 사진 url
+    private String experienceYears;
+    private String majorExperience;
+    private String introduction;
+    private String profileImageUrl;
 
     @Valid
-    private List<CertificateRequest> certificates;      // 자격증 리스트
+    @NotEmpty(message = "자격증 정보는 필수 입력 항목입니다.")
+    private List<CertificateRequest> certificates;
 
     @Getter
+    @NoArgsConstructor
     public static class CertificateRequest {
+        @NotNull(message = "자격증 종류는 필수 선택입니다.")
         private CertificateType certificateType;
 
         @NotBlank(message = "자격증 번호는 필수 입력 항목입니다.")

--- a/src/main/java/com/example/believeus/config/SecurityConfig.java
+++ b/src/main/java/com/example/believeus/config/SecurityConfig.java
@@ -1,33 +1,63 @@
 package com.example.believeus.config;
 
+import com.example.believeus.auth.JwtAuthenticationFilter;
+import com.example.believeus.auth.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/h2-console/**",
+                                "/api/v1/auth/login",
+                                "/api/v1/caregivers/signup",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .formLogin(form -> form.disable())
-                .httpBasic(httpBasic -> httpBasic.disable());
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider); 
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return new ProviderManager(authProvider);
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,7 @@ spring:
       org.hibernate.SQL: DEBUG
       org.hibernate.type.descriptor.sql.BasicBinder: TRACE
 
+jwt:
+  secret: 'mySecretKeymySecretKeymySecretKeymySecretKey'
+  access-token-expiration: 3600000
+  refresh-token-expiration: 86400000


### PR DESCRIPTION
## PR 개요
요양보호사 및 관리자 로그인을 위한 JWT 기반 통합 로그인 API를 구현하였습니다.

## 작업 내용 
- AuthController에 로그인 API 추가
- AuthService에서 사용자 인증 및 JWT 토큰 발급 구현
- JwtTokenProvider를 사용하여 JWT 생성 및 검증
- SecurityConfig 수정하여 로그인 API 접근 허용 및 JWT 필터 적용
- CustomUserDetailsService 구현하여 Spring Security에서 사용자 인증 처리

## 테스트 
#### 회원가입 후 로그인 - `/api/v1/auth/login`
```bash
curl -X POST "http://localhost:8080/api/v1/auth/login" \
     -H "Content-Type: application/json" \
     -d '{
           "username": "username123",
           "password": "password123!"
         }'
```
```json
{
  "accessToken": "Access Token 값",
  "refreshToken": "Refresh Token 값"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced JWT-based authentication, enabling secure login with access and refresh tokens.
- **Refactor**
	- Simplified the caregiver signup process with streamlined validations and enhanced certificate submission.
- **Chore**
	- Updated project configurations and dependencies to support the new security and authentication enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->