### PR TITLE
[SETTING] EC2 배포를 위한 RDS 구성 및 환경 변수 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,4 +44,10 @@ jobs:
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/springboot-api:latest
             docker stop springboot-api || true
             docker rm springboot-api || true
-            docker run -d --name springboot-api -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/springboot-api:latest
+            docker run -d --name springboot-api -p 8080:8080 \
+              -e DB_HOST=${{ secrets.DB_HOST }} \
+              -e DB_PORT=${{ secrets.DB_PORT }} \
+              -e DB_NAME=${{ secrets.DB_NAME }} \
+              -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
+              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+              ${{ secrets.DOCKERHUB_USERNAME }}/springboot-api:latest

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'mysql:mysql-connector-java:8.0.33'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+  logging:
+    level:
+      root: INFO
+      org.springframework: DEBUG
+      org.hibernate.SQL: DEBUG
+      org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+jwt:
+  secret: 'mySecretKeymySecretKeymySecretKeymySecretKey'
+  access-token-expiration: 3600000
+  refresh-token-expiration: 86400000

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+jwt:
+  secret: 'prodSecretKeyprokldSecretKeyprodSecretKeyprodSecretKey'
+  access-token-expiration: 3600000
+  refresh-token-expiration: 86400000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,30 +2,5 @@ server:
   port: 8080
 
 spring:
-  datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-
-  logging:
-    level:
-      root: INFO
-      org.springframework: DEBUG
-      org.hibernate.SQL: DEBUG
-      org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-
-jwt:
-  secret: 'mySecretKeymySecretKeymySecretKeymySecretKey'
-  access-token-expiration: 3600000
-  refresh-token-expiration: 86400000
+  profiles:
+    active: local


### PR DESCRIPTION
## PR 개요
- application-local.yml와 application-prod.yml 분리
- `application-prod.yml`에서 MySQL 연결 정보 (DB_HOST, DB_PORT, DB_NAME, DB_USERNAME, DB_PASSWORD)를 환경변수로 설정
- Secrets를 GitHub Actions 파이프라인에서 사용하여 EC2 배포 시 환경변수로 전달



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced deployment workflow now accepts secure environment variables for dynamic database connectivity.
  - Introduced dedicated configuration setups for local and production environments, offering optimized database integration, logging, and token management.
  - Upgraded database connectivity with support for MySQL, improving overall application robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->