### PR TITLE
[FEAT] Refresh Token 갱신 API 구현

### DIFF
--- a/src/main/java/com/example/believeus/auth/application/AuthService.java
+++ b/src/main/java/com/example/believeus/auth/application/AuthService.java
@@ -35,4 +35,9 @@ public class AuthService {
 
         return new LoginResponse(accessToken, refreshToken.getToken());
     }
+
+    // Access Token 생성 메서드
+    public String generateAccessToken(String username) {
+        return jwtTokenProvider.generateAccessToken(username);
+    }
 }

--- a/src/main/java/com/example/believeus/auth/application/AuthService.java
+++ b/src/main/java/com/example/believeus/auth/application/AuthService.java
@@ -1,6 +1,7 @@
 package com.example.believeus.auth.application;
 
 import com.example.believeus.auth.JwtTokenProvider;
+import com.example.believeus.auth.domain.RefreshToken;
 import com.example.believeus.auth.dto.LoginRequest;
 import com.example.believeus.auth.dto.LoginResponse;
 import com.example.believeus.caregiver.domain.Caregiver;
@@ -16,6 +17,7 @@ public class AuthService {
     private final CaregiverRepository caregiverRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     public LoginResponse login(LoginRequest request) {
         // 유저 조회
@@ -29,8 +31,8 @@ public class AuthService {
 
         // JWT 토큰 생성
         String accessToken = jwtTokenProvider.generateAccessToken(caregiver.getUsername());
-        String refreshToken = jwtTokenProvider.generateRefreshToken(caregiver.getUsername());
+        RefreshToken refreshToken = refreshTokenService.createRefreshToken(caregiver.getUsername());
 
-        return new LoginResponse(accessToken, refreshToken);
+        return new LoginResponse(accessToken, refreshToken.getToken());
     }
 }

--- a/src/main/java/com/example/believeus/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/example/believeus/auth/application/RefreshTokenService.java
@@ -6,11 +6,13 @@ import com.example.believeus.auth.repository.RefreshTokenRepository;
 import com.example.believeus.caregiver.repository.CaregiverRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import java.time.Instant;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
@@ -38,7 +40,12 @@ public class RefreshTokenService {
     // 리프레시 토큰 검증
     public Optional<RefreshToken> verifyToken(String token) {
         return refreshTokenRepository.findByToken(token)
-                .filter(rt -> rt.getExpiryDate().isAfter(Instant.now()));
+                .map(rt -> {
+                    if (rt.getExpiryDate().isBefore(Instant.now().minusSeconds(1))) {
+                        return null;
+                    }
+                    return rt;
+                });
     }
 
     // 리프레시 토큰 삭제 (로그아웃)

--- a/src/main/java/com/example/believeus/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/example/believeus/auth/application/RefreshTokenService.java
@@ -1,0 +1,49 @@
+package com.example.believeus.auth.application;
+
+import com.example.believeus.auth.JwtTokenProvider;
+import com.example.believeus.auth.domain.RefreshToken;
+import com.example.believeus.auth.repository.RefreshTokenRepository;
+import com.example.believeus.caregiver.repository.CaregiverRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CaregiverRepository caregiverRepository;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    // 리프레시 토큰 생성 및 저장
+    @Transactional
+    public RefreshToken createRefreshToken(String username) {
+        // 기존 토큰이 있으면 삭제
+        refreshTokenRepository.deleteByUsername(username);
+
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUsername(username);
+        refreshToken.setToken(jwtTokenProvider.generateRefreshToken(username));
+        refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenExpiration));
+
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+    // 리프레시 토큰 검증
+    public Optional<RefreshToken> verifyToken(String token) {
+        return refreshTokenRepository.findByToken(token)
+                .filter(rt -> rt.getExpiryDate().isAfter(Instant.now()));
+    }
+
+    // 리프레시 토큰 삭제 (로그아웃)
+    @Transactional
+    public void deleteByUsername(String username) {
+        refreshTokenRepository.deleteByUsername(username);
+    }
+}

--- a/src/main/java/com/example/believeus/auth/controller/AuthController.java
+++ b/src/main/java/com/example/believeus/auth/controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.example.believeus.auth.controller;
 
+import com.example.believeus.auth.application.RefreshTokenService;
 import com.example.believeus.auth.dto.LoginRequest;
 import com.example.believeus.auth.dto.LoginResponse;
 import com.example.believeus.auth.application.AuthService;
+import com.example.believeus.auth.dto.RefreshTokenRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+    private final RefreshTokenService refreshTokenService;
 
     @Operation(summary = "통합 로그인", description = "요양보호사/관리자 통합 로그인 API")
     @ApiResponses({
@@ -28,5 +31,15 @@ public class AuthController {
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refreshToken(@RequestBody RefreshTokenRequest request) {
+        return refreshTokenService.verifyToken(request.getRefreshToken())
+                .map(rt -> {
+                    String newAccessToken = authService.generateAccessToken(rt.getUsername());
+                    return ResponseEntity.ok(new LoginResponse(newAccessToken, rt.getToken()));
+                })
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않거나 만료된 리프레시 토큰입니다."));
     }
 }

--- a/src/main/java/com/example/believeus/auth/controller/AuthController.java
+++ b/src/main/java/com/example/believeus/auth/controller/AuthController.java
@@ -26,13 +26,18 @@ public class AuthController {
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
             @ApiResponse(responseCode = "403", description = "인증 실패"),
     })
-
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "Access Token 갱신", description = "만료된 Access Token을 Refresh Token을 이용해 갱신하는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "새로운 Access Token 발급 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "403", description = "유효하지 않거나 만료된 Refresh Token")
+    })
     @PostMapping("/refresh")
     public ResponseEntity<LoginResponse> refreshToken(@RequestBody RefreshTokenRequest request) {
         return refreshTokenService.verifyToken(request.getRefreshToken())

--- a/src/main/java/com/example/believeus/auth/domain/RefreshToken.java
+++ b/src/main/java/com/example/believeus/auth/domain/RefreshToken.java
@@ -1,0 +1,26 @@
+package com.example.believeus.auth.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.Instant;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;       // Refresh Token 값
+
+    @Column(nullable = false)
+    private String username;        // 해당 토큰이 속한 사용자 ID
+
+    @Column(nullable = false)
+    private Instant expiryDate;     // 토큰 만료일
+}

--- a/src/main/java/com/example/believeus/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/example/believeus/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,10 @@
+package com.example.believeus.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshTokenRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/example/believeus/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/believeus/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.example.believeus.auth.repository;
+
+import com.example.believeus.auth.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);       // 리프레시 토큰 조회
+    void deleteByUsername(String username);     // 사용자 로그아웃 시 기존 토큰 삭제
+}

--- a/src/main/java/com/example/believeus/config/SecurityConfig.java
+++ b/src/main/java/com/example/believeus/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/h2-console/**",
-                                "/api/v1/auth/login",
+                                "/api/v1/auth/**",
                                 "/api/v1/caregivers/signup",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,6 +21,7 @@ spring:
       org.springframework: DEBUG
       org.hibernate.SQL: DEBUG
       org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+      com.example.believeus.auth.JwtTokenProvider: DEBUG
 
 jwt:
   secret: 'mySecretKeymySecretKeymySecretKeymySecretKey'


### PR DESCRIPTION
## PR 개요
만료된 Access Token을 Refresh Token을 이용하여 갱신하는 API를 구현하였습니다. (closed #9 )
- 기존 로그인 API를 확장하여 Refresh Token을 통한 인증 및 새로운 Access Token 발급 기능 구현
- Swagger 문서(/swagger-ui.html)에 /refresh 엔드포인트 설명 추가

## 주요 변경 사항
1. /api/v1/auth/refresh 엔드포인트 구현
    - 만료된 Access Token을 갱신하는 기능 추가
    - 클라이언트가 보낸 Refresh Token을 검증하고 새로운 Access Token을 반환
2. AuthController 수정
    - @Operation 및 @ApiResponses 어노테이션을 사용하여 Swagger 문서화 적용
    - 기존 로그인 API와 동일한 방식으로 Refresh Token을 처리
3. RefreshTokenService 구현
    - 클라이언트가 JSON으로 refreshToken을 전달할 수 있도록 DTO 정의
    - verifyToken(refreshToken) 메서드 추가하여 유효한 Refresh Token인지 검증
    - 데이터베이스에서 저장된 Refresh Token의 만료 여부 확인
4. SecurityFilterChain에서 /api/v1/auth/refresh 엔드포인트를 인증 없이 접근할 수 있도록 허용

## 테스트
#### 로그인 후 Refresh Token 받기 
```bash
curl -X POST "http://localhost:8080/api/v1/auth/login" \
     -H "Content-Type: application/json" \
     -d '{
           "username": "사용자 ID",
           "password": "사용자 비밀번호"
         }'
```
```json
{
  "accessToken": "Access Token 값",
  "refreshToken": "Refresh Token 값"
}
```

#### Refresh Token으로 Access Token 갱신
```
curl -X POST "http://localhost:8080/api/v1/auth/refresh" \
     -H "Content-Type: application/json" \
     -d '{
           "refreshToken": "로그인 시 발급받은 Refresh Token 값"
         }'
```
```json
{
  "accessToken": "새로운 Access Token",
  "refreshToken": "기존 Refresh Token"
}

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced authentication with a new refresh token mechanism, enabling users to renew their session without re-entering credentials.
  - Introduced a dedicated endpoint for token refresh, streamlining the login process for uninterrupted access.
  - Expanded access to authentication routes, ensuring a smoother and more resilient user session management experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->