### PR TITLE
[FEAT] 로그아웃 API 구현 

### DIFF
--- a/src/main/java/com/example/believeus/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/example/believeus/auth/application/RefreshTokenService.java
@@ -50,7 +50,8 @@ public class RefreshTokenService {
 
     // 리프레시 토큰 삭제 (로그아웃)
     @Transactional
-    public void deleteByUsername(String username) {
-        refreshTokenRepository.deleteByUsername(username);
+    public void deleteByRefreshToken(String refreshToken) {
+        refreshTokenRepository.findByToken(refreshToken)
+                .ifPresent(rt -> refreshTokenRepository.deleteByUsername(rt.getUsername()));
     }
 }

--- a/src/main/java/com/example/believeus/auth/controller/AuthController.java
+++ b/src/main/java/com/example/believeus/auth/controller/AuthController.java
@@ -51,6 +51,12 @@ public class AuthController {
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않거나 만료된 리프레시 토큰입니다."));
     }
 
+    @Operation(summary = "로그아웃", description = "사용자의 Refresh Token을 무효화하여 로그아웃하는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "403", description = "유효하지 않거나 만료된 Refresh Token")
+    })
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@RequestBody RefreshTokenRequest request) {
         refreshTokenService.deleteByRefreshToken(request.getRefreshToken());

--- a/src/main/java/com/example/believeus/auth/controller/AuthController.java
+++ b/src/main/java/com/example/believeus/auth/controller/AuthController.java
@@ -11,7 +11,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Tag(name = "Common Auth API", description = "공통 인증/인가 API")
 @RestController
@@ -46,5 +49,12 @@ public class AuthController {
                     return ResponseEntity.ok(new LoginResponse(newAccessToken, rt.getToken()));
                 })
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않거나 만료된 리프레시 토큰입니다."));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestBody RefreshTokenRequest request) {
+        refreshTokenService.deleteByRefreshToken(request.getRefreshToken());
+        SecurityContextHolder.clearContext();
+        return ResponseEntity.ok().body(Map.of("message", "정상적으로 로그아웃되었습니다. "));
     }
 }


### PR DESCRIPTION
## 작업 내용
- `POST /api/v1/auth/logout` 엔드포인트 구현
- Refresh Token을 삭제하여 로그아웃 처리
- `SecurityContextHolder.clearContext()`를 통해 보안 컨텍스트 초기화
- Swagger 문서화 (@Operation, @ApiResponses 추가)

## 기타 참고 사항 
- Refresh Token이 유효한 경우만 삭제됨
- 요청 시 refreshToken을 JSON body로 전달해야 함

closed #5 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a secure logout option that invalidates your session tokens immediately, ensuring a more robust logout experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->