### PR TITLE
[FEAT] 관리자 회원가입 API 구현 

### DIFF
--- a/src/main/java/com/example/believeus/admin/application/AdminService.java
+++ b/src/main/java/com/example/believeus/admin/application/AdminService.java
@@ -1,0 +1,41 @@
+package com.example.believeus.admin.application;
+
+import com.example.believeus.admin.domain.Admin;
+import com.example.believeus.admin.dto.AdminSignupRequest;
+import com.example.believeus.admin.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void registerAdmin(AdminSignupRequest request) {
+        if (adminRepository.existsByUsername(request.getUsername())) {
+            throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+        }
+
+        if (!request.getPassword().equals(request.getPasswordConfirm())) {
+            throw new IllegalArgumentException("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+        }
+
+        Admin admin = new Admin(
+                request.getUsername(),
+                passwordEncoder.encode(request.getPassword()),
+                request.getName(),
+                request.getPhoneNumber(),
+                request.getCenterName(),
+                request.getHasBathVehicle(),
+                request.getAddress(),
+                request.getCenterGrade(),
+                request.getOperatingPeriod(),
+                request.getIntroduction(),
+                request.getProfileImageUrl()
+        );
+
+        adminRepository.save(admin);
+    }
+}

--- a/src/main/java/com/example/believeus/admin/controller/AdminController.java
+++ b/src/main/java/com/example/believeus/admin/controller/AdminController.java
@@ -1,0 +1,36 @@
+package com.example.believeus.admin.controller;
+
+import com.example.believeus.admin.application.AdminService;
+import com.example.believeus.admin.dto.AdminSignupRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.Map;
+
+@Tag(name = "Admin API", description = "관리자 API")
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class AdminController {
+    private final AdminService adminService;
+
+    @Operation(summary = "관리자 회원가입", description = "새로운 관리자 계정을 생성하는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 아이디"),
+    })
+    @PostMapping("/signup")
+    public ResponseEntity<?> registerAdmin(@Valid @RequestBody AdminSignupRequest request) {
+        adminService.registerAdmin(request);
+        return ResponseEntity.ok(Map.of("message", "관리자 회원가입이 완료되었습니다."));
+    }
+}

--- a/src/main/java/com/example/believeus/admin/domain/Admin.java
+++ b/src/main/java/com/example/believeus/admin/domain/Admin.java
@@ -1,0 +1,55 @@
+package com.example.believeus.admin.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Admin {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;        // 관리자 계정 ID
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;            // 관리자 실명
+
+    @Column(nullable = false, unique = true)
+    private String phoneNumber;        // 연락처
+
+    @Column(nullable = false)
+    private String centerName;          // 센터 이름
+
+    @Column(nullable = false)
+    private Boolean hasBathVehicle;     // 목욕 차량 보유 여부
+
+    @Column(nullable = false)
+    private String address;             // 센터 주소
+
+    private String centerGrade;         // 센터 등급 (선택)
+    private String operatingPeriod;      // 운영 기간 (선택)
+    private String introduction;        // 한 줄 소개 (선택)
+    private String profileImageUrl;      // 프로필 사진 URL (선택)
+
+    public Admin(String username, String password, String name, String phoneNumber, String centerName,
+                 Boolean hasBathVehicle, String address, String centerGrade, String operatingPeriod, String introduction, String profileImageUrl) {
+        this.username = username;
+        this.password = password;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.centerName = centerName;
+        this.hasBathVehicle = hasBathVehicle;
+        this.address = address;
+        this.centerGrade = centerGrade;
+        this.operatingPeriod = operatingPeriod;
+        this.introduction = introduction;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/com/example/believeus/admin/dto/AdminSignupRequest.java
+++ b/src/main/java/com/example/believeus/admin/dto/AdminSignupRequest.java
@@ -1,0 +1,43 @@
+package com.example.believeus.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminSignupRequest {
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String passwordConfirm;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
+    private String phoneNumber;
+
+    @NotBlank
+    private String centerName;          // 센터 이름
+
+    @NotNull
+    private Boolean hasBathVehicle;      // 목욕 차량 소유 여부
+
+    @NotBlank
+    private String address;             // 주소
+
+    private String centerGrade;         // 센터 등급 (선택)
+    private String operatingPeriod;      // 운영 기간 (선택)
+    private String introduction;        // 한 줄 소개 (선택)
+    private String profileImageUrl;      // 프로필 사진 URL (선택)
+}

--- a/src/main/java/com/example/believeus/admin/repository/AdminRepository.java
+++ b/src/main/java/com/example/believeus/admin/repository/AdminRepository.java
@@ -1,0 +1,12 @@
+package com.example.believeus.admin.repository;
+
+import com.example.believeus.admin.domain.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+    boolean existsByUsername(String username);
+    Optional<Admin> findByUsername(String username);
+}

--- a/src/main/java/com/example/believeus/config/SecurityConfig.java
+++ b/src/main/java/com/example/believeus/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/h2-console/**",
                                 "/api/v1/auth/**",
-                                "/api/v1/caregivers/signup",
+                                "/api/v1/admin/**",
+                                "/api/v1/caregivers/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html"


### PR DESCRIPTION
관리자 회원가입 API (`/api/v1/admin/signup`)를 구현하였습니다. (closed #3 )

1. 관리자 계정 정보를 저장할 Admin 엔티티 생성 - `/admin/domain/Admin.java`
2. 관리자 계정 조회 및 저장을 담당하는 JPA Repository - `/admin/repository/AdminRepository.java`
3. 회원가입 요청 데이터를 검증/매핑할 DTO - `/admin/dto/AdminSignupRequest.java`
4. 회원가입 로직을 처리하는 서비스 클래스 - `/admin/application/AdminService.java`
5. 관리자 회원가입 엔드포인트 구현 - `/admin/controller/AdminController.java`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a secure admin registration process that includes comprehensive validations and error handling, enabling administrative users to sign up seamlessly.
  - Enhanced API access controls by broadening permissions to cover both admin and caregiver functionalities, ensuring smoother user onboarding and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->