### PR TITLE
[FEAT] Refresh Token 역할 추가 및 로그인/토큰 갱신 로직 개선

### DIFF
--- a/src/main/java/com/example/believeus/auth/JwtTokenProvider.java
+++ b/src/main/java/com/example/believeus/auth/JwtTokenProvider.java
@@ -43,8 +43,8 @@ public class JwtTokenProvider {
     }
 
     // Refresh Token 생성
-    public String generateRefreshToken(String username) {
-        return generateToken(username, "ROLE_USER", refreshTokenExpiration);
+    public String generateRefreshToken(String username, String role) {
+        return generateToken(username, role, refreshTokenExpiration);
     }
 
     // 토큰 검증 메서드

--- a/src/main/java/com/example/believeus/auth/JwtTokenProvider.java
+++ b/src/main/java/com/example/believeus/auth/JwtTokenProvider.java
@@ -1,11 +1,6 @@
 package com.example.believeus.auth;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.SignatureException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,27 +26,28 @@ public class JwtTokenProvider {
         this.refreshTokenExpiration = refreshTokenExpiration;
     }
 
-    // JWT 토큰 생성
-    public String generateToken(String username, long expiration) {
+    // 공통적인 토큰 생성 메서드
+    private String generateToken(String username, String role, long expiration) {
         return Jwts.builder()
                 .subject(username)
+                .claim("role", role)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(key)
                 .compact();
     }
 
-    // 액세스 토큰 생성
-    public String generateAccessToken(String username) {
-        return generateToken(username, accessTokenExpiration);
+    // Access Token 생성
+    public String generateAccessToken(String username, String role) {
+        return generateToken(username, role, accessTokenExpiration);
     }
 
-    // 리프레시 토큰 생성
+    // Refresh Token 생성
     public String generateRefreshToken(String username) {
-        return generateToken(username, refreshTokenExpiration);
+        return generateToken(username, "ROLE_USER", refreshTokenExpiration);
     }
 
-    // 토큰 검증
+    // 토큰 검증 메서드
     public boolean validateToken(String token) {
         try {
             Jwts.parser()
@@ -73,14 +69,14 @@ public class JwtTokenProvider {
         return false;
     }
 
-    // 토큰에서 사용자 정보 추출
-    public String getUsernameFromToken(String token) {
+    // 역할(role) 정보 추출
+    public String getRoleFromToken(String token) {
         Claims claims = Jwts.parser()
                 .verifyWith(key)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
-        return claims.getSubject();
+        return claims.get("role", String.class);
     }
 
     // 토큰에서 Claims 정보 추출

--- a/src/main/java/com/example/believeus/auth/application/AuthService.java
+++ b/src/main/java/com/example/believeus/auth/application/AuthService.java
@@ -6,38 +6,57 @@ import com.example.believeus.auth.dto.LoginRequest;
 import com.example.believeus.auth.dto.LoginResponse;
 import com.example.believeus.caregiver.domain.Caregiver;
 import com.example.believeus.caregiver.repository.CaregiverRepository;
+import com.example.believeus.admin.domain.Admin;
+import com.example.believeus.admin.repository.AdminRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-
     private final CaregiverRepository caregiverRepository;
+    private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
 
     public LoginResponse login(LoginRequest request) {
-        // 유저 조회
-        Caregiver caregiver = caregiverRepository.findByUsername(request.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 잘못되었습니다."));
+        Optional<Caregiver> caregiver = caregiverRepository.findByUsername(request.getUsername());
+        Optional<Admin> admin = adminRepository.findByUsername(request.getUsername());
 
-        // 비밀번호 검증
-        if (!passwordEncoder.matches(request.getPassword(), caregiver.getPassword())) {
-            throw new IllegalArgumentException("아이디 또는 비밀번호가 잘못되었습니다.");
+        // 요양보호사 로그인 로직
+        if (caregiver.isPresent() && passwordEncoder.matches(request.getPassword(), caregiver.get().getPassword())) {
+            String accessToken = jwtTokenProvider.generateAccessToken(caregiver.get().getUsername(), "ROLE_CAREGIVER");
+            RefreshToken refreshToken = refreshTokenService.createRefreshToken(caregiver.get().getUsername());
+            return new LoginResponse(accessToken, refreshToken.getToken());
         }
 
-        // JWT 토큰 생성
-        String accessToken = jwtTokenProvider.generateAccessToken(caregiver.getUsername());
-        RefreshToken refreshToken = refreshTokenService.createRefreshToken(caregiver.getUsername());
+        // 관리자 로그인 로직
+        if (admin.isPresent() && passwordEncoder.matches(request.getPassword(), admin.get().getPassword())) {
+            String accessToken = jwtTokenProvider.generateAccessToken(admin.get().getUsername(), "ROLE_ADMIN");
+            RefreshToken refreshToken = refreshTokenService.createRefreshToken(admin.get().getUsername());
+            return new LoginResponse(accessToken, refreshToken.getToken());
+        }
 
-        return new LoginResponse(accessToken, refreshToken.getToken());
+        // 로그인 실패 (아이디 또는 비밀번호 불일치)
+        throw new IllegalArgumentException("아이디 또는 비밀번호가 잘못되었습니다.");
     }
 
-    // Access Token 생성 메서드
-    public String generateAccessToken(String username) {
-        return jwtTokenProvider.generateAccessToken(username);
+    public String getUserRole(String username) {
+        if (caregiverRepository.findByUsername(username).isPresent()) {
+            return "ROLE_CAREGIVER";
+        }
+        if (adminRepository.findByUsername(username).isPresent()) {
+            return "ROLE_ADMIN";
+        }
+        throw new IllegalArgumentException("해당 사용자를 찾을 수 없습니다.");
+    }
+
+    // Access Token 생성
+    public String generateAccessToken(String username, String role) {
+        return jwtTokenProvider.generateAccessToken(username, role);
     }
 }

--- a/src/main/java/com/example/believeus/auth/application/AuthService.java
+++ b/src/main/java/com/example/believeus/auth/application/AuthService.java
@@ -29,15 +29,17 @@ public class AuthService {
 
         // 요양보호사 로그인 로직
         if (caregiver.isPresent() && passwordEncoder.matches(request.getPassword(), caregiver.get().getPassword())) {
-            String accessToken = jwtTokenProvider.generateAccessToken(caregiver.get().getUsername(), "ROLE_CAREGIVER");
-            RefreshToken refreshToken = refreshTokenService.createRefreshToken(caregiver.get().getUsername());
+            String role = "ROLE_CAREGIVER";
+            String accessToken = jwtTokenProvider.generateAccessToken(caregiver.get().getUsername(), role);
+            RefreshToken refreshToken = refreshTokenService.createRefreshToken(caregiver.get().getUsername(), role);
             return new LoginResponse(accessToken, refreshToken.getToken());
         }
 
         // 관리자 로그인 로직
         if (admin.isPresent() && passwordEncoder.matches(request.getPassword(), admin.get().getPassword())) {
-            String accessToken = jwtTokenProvider.generateAccessToken(admin.get().getUsername(), "ROLE_ADMIN");
-            RefreshToken refreshToken = refreshTokenService.createRefreshToken(admin.get().getUsername());
+            String role = "ROLE_ADMIN";
+            String accessToken = jwtTokenProvider.generateAccessToken(admin.get().getUsername(), role);
+            RefreshToken refreshToken = refreshTokenService.createRefreshToken(admin.get().getUsername(), role);
             return new LoginResponse(accessToken, refreshToken.getToken());
         }
 

--- a/src/main/java/com/example/believeus/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/example/believeus/auth/application/RefreshTokenService.java
@@ -4,6 +4,7 @@ import com.example.believeus.auth.JwtTokenProvider;
 import com.example.believeus.auth.domain.RefreshToken;
 import com.example.believeus.auth.repository.RefreshTokenRepository;
 import com.example.believeus.caregiver.repository.CaregiverRepository;
+import com.example.believeus.admin.repository.AdminRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,19 +20,21 @@ public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final CaregiverRepository caregiverRepository;
+    private final AdminRepository adminRepository;
 
     @Value("${jwt.refresh-token-expiration}")
     private long refreshTokenExpiration;
 
-    // 리프레시 토큰 생성 및 저장
+    // 리프레시 토큰 생성 및 저장 (요양보호사 & 관리자)
     @Transactional
-    public RefreshToken createRefreshToken(String username) {
+    public RefreshToken createRefreshToken(String username, String role) {
         // 기존 토큰이 있으면 삭제
         refreshTokenRepository.deleteByUsername(username);
 
         RefreshToken refreshToken = new RefreshToken();
         refreshToken.setUsername(username);
-        refreshToken.setToken(jwtTokenProvider.generateRefreshToken(username));
+        refreshToken.setRole(role);
+        refreshToken.setToken(jwtTokenProvider.generateRefreshToken(username, role)); 
         refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenExpiration));
 
         return refreshTokenRepository.save(refreshToken);
@@ -40,12 +43,7 @@ public class RefreshTokenService {
     // 리프레시 토큰 검증
     public Optional<RefreshToken> verifyToken(String token) {
         return refreshTokenRepository.findByToken(token)
-                .map(rt -> {
-                    if (rt.getExpiryDate().isBefore(Instant.now().minusSeconds(1))) {
-                        return null;
-                    }
-                    return rt;
-                });
+                .filter(rt -> rt.getExpiryDate().isAfter(Instant.now()));
     }
 
     // 리프레시 토큰 삭제 (로그아웃)

--- a/src/main/java/com/example/believeus/auth/controller/AuthController.java
+++ b/src/main/java/com/example/believeus/auth/controller/AuthController.java
@@ -1,10 +1,12 @@
 package com.example.believeus.auth.controller;
 
+import com.example.believeus.admin.repository.AdminRepository;
 import com.example.believeus.auth.application.RefreshTokenService;
 import com.example.believeus.auth.dto.LoginRequest;
 import com.example.believeus.auth.dto.LoginResponse;
 import com.example.believeus.auth.application.AuthService;
 import com.example.believeus.auth.dto.RefreshTokenRequest;
+import com.example.believeus.caregiver.repository.CaregiverRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -23,6 +25,8 @@ import java.util.Map;
 public class AuthController {
     private final AuthService authService;
     private final RefreshTokenService refreshTokenService;
+    private final CaregiverRepository caregiverRepository;
+    private final AdminRepository adminRepository;
 
     @Operation(summary = "통합 로그인", description = "요양보호사/관리자 통합 로그인 API")
     @ApiResponses({
@@ -45,7 +49,8 @@ public class AuthController {
     public ResponseEntity<LoginResponse> refreshToken(@RequestBody RefreshTokenRequest request) {
         return refreshTokenService.verifyToken(request.getRefreshToken())
                 .map(rt -> {
-                    String newAccessToken = authService.generateAccessToken(rt.getUsername());
+                    String role = authService.getUserRole(rt.getUsername());
+                    String newAccessToken = authService.generateAccessToken(rt.getUsername(), role);
                     return ResponseEntity.ok(new LoginResponse(newAccessToken, rt.getToken()));
                 })
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않거나 만료된 리프레시 토큰입니다."));

--- a/src/main/java/com/example/believeus/auth/domain/RefreshToken.java
+++ b/src/main/java/com/example/believeus/auth/domain/RefreshToken.java
@@ -23,4 +23,14 @@ public class RefreshToken {
 
     @Column(nullable = false)
     private Instant expiryDate;     // 토큰 만료일
+
+    @Column(nullable = false)
+    private String role;
+
+    public RefreshToken(String token, String username, Instant expiryDate, String role) {
+        this.token = token;
+        this.username = username;
+        this.expiryDate = expiryDate;
+        this.role = role;
+    }
 }


### PR DESCRIPTION
JWT 토큰에 역할(role) 정보를 추가하고 로그인 및 Refresh Token 갱신 시 역할을 유지하도록 개선하였습니다.
closed #15 

- JWT 토큰에 role 추가 → generateAccessToken(username, role), generateRefreshToken(username, role) 수정
- RefreshToken 엔티티에 role 필드를 추가하여 역할 정보 저장 및 유지
- AuthService 수정 → 로그인 시 `ROLE_CAREGIVER` 또는 `ROLE_ADMIN` 부여
- Refresh Token 갱신 시 역할 유지 → authService.generateAccessToken(rt.getUsername(), rt.getRole()) 방식으로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced authentication by embedding user roles into access and refresh tokens.
  - Expanded login support to distinguish between caregiver and admin accounts with improved validation and error handling.

- **Refactor**
  - Streamlined token management processes to better filter expired tokens and ensure only valid tokens are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->