### PR TITLE
feat: 노인(senior)엔티티 생성, QueryDSL의존성 추가 및 Qclass 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,32 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // QueyrDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+///// Querydsl 빌드 옵션 (옵셔널)
+def generated = 'src/main/generated'
+
+///// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+///// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+///// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }

--- a/src/main/generated/com/example/believeus/admin/domain/QAdmin.java
+++ b/src/main/generated/com/example/believeus/admin/domain/QAdmin.java
@@ -1,0 +1,59 @@
+package com.example.believeus.admin.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAdmin is a Querydsl query type for Admin
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAdmin extends EntityPathBase<Admin> {
+
+    private static final long serialVersionUID = 845346065L;
+
+    public static final QAdmin admin = new QAdmin("admin");
+
+    public final StringPath address = createString("address");
+
+    public final StringPath centerGrade = createString("centerGrade");
+
+    public final StringPath centerName = createString("centerName");
+
+    public final BooleanPath hasBathVehicle = createBoolean("hasBathVehicle");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath introduction = createString("introduction");
+
+    public final StringPath name = createString("name");
+
+    public final StringPath operatingPeriod = createString("operatingPeriod");
+
+    public final StringPath password = createString("password");
+
+    public final StringPath phoneNumber = createString("phoneNumber");
+
+    public final StringPath profileImageUrl = createString("profileImageUrl");
+
+    public final StringPath username = createString("username");
+
+    public QAdmin(String variable) {
+        super(Admin.class, forVariable(variable));
+    }
+
+    public QAdmin(Path<? extends Admin> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAdmin(PathMetadata metadata) {
+        super(Admin.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/believeus/auth/domain/QRefreshToken.java
+++ b/src/main/generated/com/example/believeus/auth/domain/QRefreshToken.java
@@ -1,0 +1,45 @@
+package com.example.believeus.auth.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QRefreshToken is a Querydsl query type for RefreshToken
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRefreshToken extends EntityPathBase<RefreshToken> {
+
+    private static final long serialVersionUID = 177431855L;
+
+    public static final QRefreshToken refreshToken = new QRefreshToken("refreshToken");
+
+    public final DateTimePath<java.time.Instant> expiryDate = createDateTime("expiryDate", java.time.Instant.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath role = createString("role");
+
+    public final StringPath token = createString("token");
+
+    public final StringPath username = createString("username");
+
+    public QRefreshToken(String variable) {
+        super(RefreshToken.class, forVariable(variable));
+    }
+
+    public QRefreshToken(Path<? extends RefreshToken> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QRefreshToken(PathMetadata metadata) {
+        super(RefreshToken.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/believeus/caregiver/domain/QCaregiver.java
+++ b/src/main/generated/com/example/believeus/caregiver/domain/QCaregiver.java
@@ -1,0 +1,60 @@
+package com.example.believeus.caregiver.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCaregiver is a Querydsl query type for Caregiver
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCaregiver extends EntityPathBase<Caregiver> {
+
+    private static final long serialVersionUID = -52957263L;
+
+    public static final QCaregiver caregiver = new QCaregiver("caregiver");
+
+    public final ListPath<CaregiverCertificate, QCaregiverCertificate> certificates = this.<CaregiverCertificate, QCaregiverCertificate>createList("certificates", CaregiverCertificate.class, QCaregiverCertificate.class, PathInits.DIRECT2);
+
+    public final StringPath experienceYears = createString("experienceYears");
+
+    public final BooleanPath hasDementiaTraining = createBoolean("hasDementiaTraining");
+
+    public final BooleanPath hasVehicle = createBoolean("hasVehicle");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath introduction = createString("introduction");
+
+    public final StringPath majorExperience = createString("majorExperience");
+
+    public final StringPath name = createString("name");
+
+    public final StringPath password = createString("password");
+
+    public final StringPath phoneNumber = createString("phoneNumber");
+
+    public final StringPath profileImageUrl = createString("profileImageUrl");
+
+    public final StringPath username = createString("username");
+
+    public QCaregiver(String variable) {
+        super(Caregiver.class, forVariable(variable));
+    }
+
+    public QCaregiver(Path<? extends Caregiver> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QCaregiver(PathMetadata metadata) {
+        super(Caregiver.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/believeus/caregiver/domain/QCaregiverCertificate.java
+++ b/src/main/generated/com/example/believeus/caregiver/domain/QCaregiverCertificate.java
@@ -1,0 +1,55 @@
+package com.example.believeus.caregiver.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCaregiverCertificate is a Querydsl query type for CaregiverCertificate
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCaregiverCertificate extends EntityPathBase<CaregiverCertificate> {
+
+    private static final long serialVersionUID = 1774776614L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCaregiverCertificate caregiverCertificate = new QCaregiverCertificate("caregiverCertificate");
+
+    public final QCaregiver caregiver;
+
+    public final StringPath certificateNumber = createString("certificateNumber");
+
+    public final EnumPath<CertificateType> certificateType = createEnum("certificateType", CertificateType.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public QCaregiverCertificate(String variable) {
+        this(CaregiverCertificate.class, forVariable(variable), INITS);
+    }
+
+    public QCaregiverCertificate(Path<? extends CaregiverCertificate> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCaregiverCertificate(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCaregiverCertificate(PathMetadata metadata, PathInits inits) {
+        this(CaregiverCertificate.class, metadata, inits);
+    }
+
+    public QCaregiverCertificate(Class<? extends CaregiverCertificate> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.caregiver = inits.isInitialized("caregiver") ? new QCaregiver(forProperty("caregiver")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/believeus/senior/QSenior.java
+++ b/src/main/generated/com/example/believeus/senior/QSenior.java
@@ -1,0 +1,65 @@
+package com.example.believeus.senior;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QSenior is a Querydsl query type for Senior
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSenior extends EntityPathBase<Senior> {
+
+    private static final long serialVersionUID = -1007870879L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QSenior senior = new QSenior("senior");
+
+    public final StringPath address = createString("address");
+
+    public final com.example.believeus.admin.domain.QAdmin admin;
+
+    public final DatePath<java.time.LocalDate> birthDate = createDate("birthDate", java.time.LocalDate.class);
+
+    public final EnumPath<Senior.CareGrade> careGrade = createEnum("careGrade", Senior.CareGrade.class);
+
+    public final StringPath careNeeds = createString("careNeeds");
+
+    public final DatePath<java.time.LocalDate> createdAt = createDate("createdAt", java.time.LocalDate.class);
+
+    public final EnumPath<Senior.Gender> gender = createEnum("gender", Senior.Gender.class);
+
+    public final NumberPath<Integer> id = createNumber("id", Integer.class);
+
+    public final StringPath name = createString("name");
+
+    public QSenior(String variable) {
+        this(Senior.class, forVariable(variable), INITS);
+    }
+
+    public QSenior(Path<? extends Senior> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QSenior(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QSenior(PathMetadata metadata, PathInits inits) {
+        this(Senior.class, metadata, inits);
+    }
+
+    public QSenior(Class<? extends Senior> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.admin = inits.isInitialized("admin") ? new com.example.believeus.admin.domain.QAdmin(forProperty("admin")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/believeus/workingcondition/domain/QWorkingCondition.java
+++ b/src/main/generated/com/example/believeus/workingcondition/domain/QWorkingCondition.java
@@ -1,0 +1,43 @@
+package com.example.believeus.workingcondition.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QWorkingCondition is a Querydsl query type for WorkingCondition
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QWorkingCondition extends EntityPathBase<WorkingCondition> {
+
+    private static final long serialVersionUID = 1165406109L;
+
+    public static final QWorkingCondition workingCondition = new QWorkingCondition("workingCondition");
+
+    public final StringPath availableTime = createString("availableTime");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath location = createString("location");
+
+    public final NumberPath<Integer> preferredSalary = createNumber("preferredSalary", Integer.class);
+
+    public QWorkingCondition(String variable) {
+        super(WorkingCondition.class, forVariable(variable));
+    }
+
+    public QWorkingCondition(Path<? extends WorkingCondition> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QWorkingCondition(PathMetadata metadata) {
+        super(WorkingCondition.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/example/believeus/senior/Senior.java
+++ b/src/main/java/com/example/believeus/senior/Senior.java
@@ -1,0 +1,55 @@
+package com.example.believeus.senior;
+
+import com.example.believeus.admin.domain.Admin;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+
+@Entity @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Senior {
+    @Id
+    @Comment("노인 ID") private int id;
+    @Comment("노인 이름") private String name;
+    @Comment("생년월일") private LocalDate birthDate;
+    public enum Gender {
+        MALE, // 남
+        FEMALE // 여
+    }
+    @Comment("성별") private Gender gender;
+    public enum CareGrade {
+        FIRST, // 1등급
+        SECOND,  // 2등급
+        THIRD, // 3등급
+        FOURTH, // 4등급
+        FIFTH, // 5등급
+        COGNITIVE_SUPPORT // 인지지원등급
+    }
+    @Comment("장기요양등급") private CareGrade careGrade;
+    @Comment("주소") private String address;
+
+    @Comment("케어 필요 항목") private String careNeeds;
+    @CreatedDate @Comment("등록 일자") private LocalDate createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id") @Comment("관리자 ID")
+    private Admin admin;
+
+    @Builder
+    public Senior(String name, LocalDate birthDate, Gender gender, CareGrade careGrade, String address, String careNeeds) {
+        this.name = name;
+        this.birthDate = birthDate;
+        this.gender = gender;
+        this.careGrade = careGrade;
+        this.address = address;
+        this.careNeeds = careNeeds;
+    }
+}

--- a/src/main/java/com/example/believeus/senior/repository/SeniorRepository.java
+++ b/src/main/java/com/example/believeus/senior/repository/SeniorRepository.java
@@ -1,0 +1,16 @@
+package com.example.believeus.senior.repository;
+
+import com.example.believeus.senior.QSenior;
+import com.example.believeus.senior.Senior;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SeniorRepository extends
+        JpaRepository<Senior, Long>,
+        QuerydslPredicateExecutor<Senior>,
+        QuerydslBinderCustomizer<QSenior> {
+    
+}


### PR DESCRIPTION
## PR 개요
- QueyrDSL 사용을 위한 의존성을 추가하였습니다
- Senior 엔티티를 생성하였습니다

## 주요 변경 사항
- [ ] build.gradle 의존성 추가
- [ ] Senior(노인) 엔티티 생성할때 JpaAuditing을 사용하여 createdAt 컬럼을 생성하였습니다
- [ ] QueryDSL 사용을 위한 Qclass 생성을 하였습니다

## 확인해야 할 항목
- [ ] 로컬 테스트 완료
- [ ] CI/CD (GitHub Actions) 테스트 통과
- [ ] 보안 & 예외 처리 확인
- [ ] API 명세 업데이트

## 기타 참고 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced dynamic query functionality that improves data search and filtering.
	- Launched a new module to manage senior citizen information, offering comprehensive detail tracking and better record associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->