### PR TITLE
Feature/admin

### DIFF
--- a/src/main/java/com/example/believeus/admin/application/AdminService.java
+++ b/src/main/java/com/example/believeus/admin/application/AdminService.java
@@ -60,7 +60,7 @@ public class AdminService {
                 .map(senior -> SeniorListResponse.builder()
                         .name(senior.getName())
                         .age(senior.getAge() + "세")
-                        .gender(senior.getGender().toString().equals("MALE") ? "남" : "여")
+                        .gender(senior.getGender() == Senior.Gender.MALE ? "남" : "여")
                         .build()).collect(Collectors.toList());
 
         return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/src/main/java/com/example/believeus/admin/application/AdminService.java
+++ b/src/main/java/com/example/believeus/admin/application/AdminService.java
@@ -2,19 +2,28 @@ package com.example.believeus.admin.application;
 
 import com.example.believeus.admin.domain.Admin;
 import com.example.believeus.admin.dto.AdminDetailsRequestDTO;
+import com.example.believeus.admin.dto.SeniorListResponse;
 import com.example.believeus.admin.repository.AdminRepository;
 import com.example.believeus.auth.domain.Role;
 import com.example.believeus.auth.domain.User;
 import com.example.believeus.auth.repository.UserRepository;
+import com.example.believeus.senior.Senior;
+import com.example.believeus.senior.repository.SeniorRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class AdminService {
     private final AdminRepository adminRepository;
     private final UserRepository userRepository;
+    private final SeniorRepository seniorRepository;
 
     @Transactional
     public void registerAdminDetails(AdminDetailsRequestDTO request) {
@@ -41,4 +50,20 @@ public class AdminService {
 
         adminRepository.save(admin);
     }
+
+    @Transactional(rollbackFor = Exception.class)
+    public ResponseEntity<List<SeniorListResponse>> seniors() {
+        List<Senior> seniors = seniorRepository.findAll();
+
+        // Senior 객체를 SeniorListResponse로 변환
+        List<SeniorListResponse> response = seniors.stream()
+                .map(senior -> SeniorListResponse.builder()
+                        .name(senior.getName())
+                        .age(senior.getAge() + "세")
+                        .gender(senior.getGender().toString().equals("MALE") ? "남" : "여")
+                        .build()).collect(Collectors.toList());
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
 }

--- a/src/main/java/com/example/believeus/admin/controller/AdminController.java
+++ b/src/main/java/com/example/believeus/admin/controller/AdminController.java
@@ -1,9 +1,14 @@
 package com.example.believeus.admin.controller;
 
 import com.example.believeus.admin.application.AdminService;
+import com.example.believeus.admin.dto.SeniorListResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Admin API", description = "관리자 API")
 @RestController
@@ -11,4 +16,10 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AdminController {
     private final AdminService adminService;
+
+    @Operation(summary = "전체 어르신 목록 조회", description = "전체 어르신의 정보를 가져옵니다")
+    @GetMapping("/seniors")
+    public ResponseEntity<List<SeniorListResponse>> getSeniors() {
+        return adminService.seniors();
+    }
 }

--- a/src/main/java/com/example/believeus/admin/controller/AdminController.java
+++ b/src/main/java/com/example/believeus/admin/controller/AdminController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,6 +19,7 @@ public class AdminController {
     private final AdminService adminService;
 
     @Operation(summary = "전체 어르신 목록 조회", description = "전체 어르신의 정보를 가져옵니다")
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/seniors")
     public ResponseEntity<List<SeniorListResponse>> getSeniors() {
         return adminService.seniors();

--- a/src/main/java/com/example/believeus/admin/dto/SeniorListResponse.java
+++ b/src/main/java/com/example/believeus/admin/dto/SeniorListResponse.java
@@ -1,0 +1,12 @@
+package com.example.believeus.admin.dto;
+
+import lombok.Builder;
+
+@Builder
+public record SeniorListResponse(
+    String name,
+    String age,
+    String gender
+) {
+
+}

--- a/src/main/java/com/example/believeus/senior/Senior.java
+++ b/src/main/java/com/example/believeus/senior/Senior.java
@@ -35,6 +35,7 @@ public class Senior {
         FIFTH, // 5등급
         COGNITIVE_SUPPORT // 인지지원등급
     }
+    @Comment("노인 나이") private int age;
     @Comment("장기요양등급") private CareGrade careGrade;
     @Comment("주소") private String address;
 
@@ -49,10 +50,11 @@ public class Senior {
     private Admin admin;
 
     @Builder
-    public Senior(String name, LocalDate birthDate, Gender gender, CareGrade careGrade, String address, String careNeeds, Admin admin) {
+    public Senior(String name, LocalDate birthDate, Gender gender, int age, CareGrade careGrade, String address, String careNeeds, Admin admin) {
         this.name = name;
         this.birthDate = birthDate;
         this.gender = gender;
+        this.age = age;
         this.careGrade = careGrade;
         this.address = address;
         this.careNeeds = careNeeds;


### PR DESCRIPTION
## PR 개요
Senior 엔티티 나이 컬럼 추가
어르신 전체 정보 조회 API

## 확인해야 할 항목
- [ ] 로컬 테스트 완료
- [ ] CI/CD (GitHub Actions) 테스트 통과
- [ ] 보안 & 예외 처리 확인
- [ ] API 명세 업데이트

## 기타 참고 사항
SeniorListResponse에서 프론트엔드 단에서 관리하기 편하도록 성별을 문자열 변환해서 응답하였습니다
나이 응답 시 나이 + "세" 형식으로 응답합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an API endpoint that displays a list of senior profiles with formatted details.
  - Enabled administrative functionality to fetch senior information including name, age (with a friendly suffix), and gender.
  - Added a new data structure for representing senior details.
  - Updated senior records to incorporate an age attribute for more comprehensive profile information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->